### PR TITLE
fix: modal and room page height

### DIFF
--- a/src/components/AnimatedModal/AnimatedModal.tsx
+++ b/src/components/AnimatedModal/AnimatedModal.tsx
@@ -23,6 +23,7 @@ function ModalContent({ children }: { children: React.ReactNode }) {
       variants={SCALE_MOTION_VARIANTS}
       transition={SCALE_MOTION_TRANSITIONS}
       key="modal-motion"
+      onClick={(e) => e.stopPropagation()}
     >
       {children}
     </motion.div>
@@ -56,7 +57,8 @@ function AnimatedModal({
         'grid',
         'place-items-center',
         'transition',
-        'will-change-transform'
+        'will-change-transform',
+        'z-50'
       ])}
       contentLabel="Settings modal"
       closeTimeoutMS={150}

--- a/src/pages/Room/Room.tsx
+++ b/src/pages/Room/Room.tsx
@@ -161,7 +161,9 @@ function Room() {
   return (
     <div className="h-dvh">
       <Toaster />
-      <div className={clsm(['flex', 'flex-col', 'gap-2', 'sm:gap-2.5'])}>
+      <div
+        className={clsm(['flex', 'flex-col', 'gap-2', 'sm:gap-2.5', 'h-full'])}
+      >
         <div
           className={clsm([
             'flex',
@@ -172,7 +174,7 @@ function Room() {
             'py-3',
             'sm:p-8',
             'xswh:p-2',
-            'h-[calc(100vh_-_76px)]'
+            'h-[calc(100%_-_76px)]'
           ])}
         >
           <div

--- a/src/pages/Room/Room.tsx
+++ b/src/pages/Room/Room.tsx
@@ -159,7 +159,7 @@ function Room() {
   });
 
   return (
-    <div>
+    <div className="h-dvh">
       <Toaster />
       <div className={clsm(['flex', 'flex-col', 'gap-2', 'sm:gap-2.5'])}>
         <div


### PR DESCRIPTION
This update fixes these front end issues:
- Modal content on click will close the modal - added stopPropagation to the onClick handler
- Modal backdrop/overlay does not cover the controls at the bottom of the screen - increased z-index to 50 `z-50` 
- On Safari mobile, the bottom section or the media controls are covered by the browser search bar UI. Fixed by adding `height: 100dvh` or `h-dvh` class to the main parent div on the Room page. Then update the grid layout wrapper div to calculate height using 100% instead of 100vh. 